### PR TITLE
Responsive layouts

### DIFF
--- a/src/client/components/App.jsx
+++ b/src/client/components/App.jsx
@@ -24,7 +24,7 @@ class Nav extends React.Component {
             <img alt="Webpack logo" className={styles.logo}src={logo} />
           </NavLink>
           <button>
-            <span>+</span> New Project
+            + &nbsp;New Project
           </button>
         </div>
       </nav>

--- a/src/client/components/home/Home.jsx
+++ b/src/client/components/home/Home.jsx
@@ -28,12 +28,11 @@ class Home extends React.Component {
               onClick={() => {
                 this.props.history.push('/newProject');
               }}>
-              <span>+</span> Create Project
+              + &nbsp;Create Project
             </button>
           </div>
           <div className={styles.rightContainer}>
-            <div style={{ width: '320px' }}>No Activity here. Create a project to get started</div>
-            <hr />
+            <div className={styles.noActivity}>No Activity here. Create a project to get started</div>
           </div>
         </div>
       </div>

--- a/src/client/stylesheets/modules/DefaultStarter.module.scss
+++ b/src/client/stylesheets/modules/DefaultStarter.module.scss
@@ -7,9 +7,12 @@
 
 .lowerContainer {
   padding-top: 30px;
-  padding-left: 10px;
   display: flex;
   flex-direction: row;
+
+  @media (min-width: 1160px) {
+    padding-left: 10px;
+  }
 
   .questionContainer {
     display: flex;
@@ -18,8 +21,10 @@
   }
 }
 
-.lowerRightContainer {
-  margin-left: 50px;
+@media (min-width: 1160px) {
+  .lowerRightContainer {
+    margin-left: 50px;
+  }
 }
 
 .header {

--- a/src/client/stylesheets/modules/NewProject.module.scss
+++ b/src/client/stylesheets/modules/NewProject.module.scss
@@ -6,10 +6,15 @@
 }
 
 .lowerContainer {
+  align-items: center;
   padding-top: 30px;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: center;
+
+  @media (min-width: 580px) {
+    flex-direction: row;
+  }
 }
 
 .header {
@@ -23,21 +28,31 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 380px;
-  width: 380px;
+  height: 300px;
+  width: 100%;
   background-color: #f1f6fa93;
   border: 1px solid darken(#f1f6fa93, 20%);
   border-radius: 7px;
-  margin: 30px;
+  margin: 1rem 2rem;
   cursor: pointer;
+
+  @media (min-width: 580px) {
+    margin: 2rem;
+    height: 380px;
+    width: 380px;
+  }
 }
 
 .description {
   font-size: 18px;
-  width: 200px;
   text-align: center;
   color: #999999;
   margin: 20px;
+  width: 80%;
+
+  @media (min-width: 1160px) {
+    width: 200px;
+  }
 }
 
 .optionIcon {

--- a/src/client/stylesheets/modules/SelectStarterPack.module.scss
+++ b/src/client/stylesheets/modules/SelectStarterPack.module.scss
@@ -8,16 +8,30 @@
 .lowerContainer {
   padding-top: 30px;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  align-items: stretch;
 
-  .lowerLeftTopContainer {
-    display: flex;
+  @media (min-width: 1160px) {
+    flex-direction: row;
+  }
+}
+
+.lowerLeftTopContainer {
+  display: flex;
+  flex-direction: column;
+
+  @media (min-width: 580px) {
     flex-direction: row;
   }
 }
 
 .lowerRightContainer {
-  margin-left: 90px;
+  align-self: center;
+  margin-top: 2rem;
+
+  @media (min-width: 1160px) {
+    margin-left: 3.5rem;
+  }
 }
 
 .header {
@@ -28,15 +42,25 @@
 
 .optionContainer {
   display: flex;
+  align-items: center;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 190px;
-  width: 190px;
+  width: 100%;
+  height: auto;
+  padding: 0.5rem;
   background-color: #f1f6fa93;
   border: 1px solid darken(#f1f6fa93, 20%);
   border-radius: 5px;
-  margin: 15px;
+  margin: 1rem 0;
+
+  @media (min-width: 580px) {
+    margin: 1rem;
+  }
+
+  @media (min-width: 1160px) {
+    min-width: 190px;
+  }
 
   .optionHeader {
     color: black;

--- a/src/client/stylesheets/modules/app.module.scss
+++ b/src/client/stylesheets/modules/app.module.scss
@@ -1,47 +1,59 @@
-@import "../utils/styles";
+@import '../utils/styles';
 
 .Nav {
-  position: fixed;
   background-color: #2b3a42;
   width: 100%;
-  height: 240px;
   display: flex;
   flex-direction: row;
   justify-content: center;
   box-shadow: 9px 0px 25px 2px darken($bg-color, 13%);
+
+  @media (min-width: 1160px) {
+    padding-bottom: 7.5rem;
+    margin-bottom: -7.5rem;
+  }
 }
 
 .mainContainer {
+  box-sizing: border-box;
   padding: 30px;
-  position: absolute;
-  top: 120px;
-  width: 1100px;
-  height: 580px;
-  border-radius: 8px;
+  width: 100%;
+  min-height: 580px;
   background-color: white;
-  box-shadow: 9px 0px 25px 2px rbga(0, 0, 0, .5);
+  box-shadow: 9px 0px 25px 2px rbga(0, 0, 0, 0.5);
+
+  @media (min-width: 1160px) {
+    border-radius: 8px;
+    max-width: 100%;
+    width: 1170px;
+  }
 }
 
 .fullAppContainer {
+  align-items: center;
   display: flex;
-  justify-content: center;
-  @media (max-width: 1160px) {
-    justify-content: space-between;
+  flex-direction: column;
+  justify-content: space-between;
+
+  @media (min-width: 1160px) {
+    justify-content: center;
   }
 }
 
 button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 130px;
   background-color: #1d78c1;
   border: none;
   border-radius: 5px;
   color: white;
-  padding: 10px 15px;
   font-size: 13px;
   height: 40px;
   cursor: pointer;
-  border: 2px solid transparent;
-  transition: border-color .2s;
+  opacity: 0.92;
+  transition: opacity 0.2s;
 }
 
 button:hover {
@@ -63,12 +75,10 @@ button:hover {
 }
 
 .footer {
-  padding-bottom: 40px;
+  padding: 40px;
   display: flex;
-  width: 1100px;
+  max-width: 1100px;
+  width: 100%;
   justify-content: space-between;
-  transform: translate(0, 800px);
-  @media (max-width: 1160px) {
-    justify-content: space-around;
-  }
+  box-sizing: border-box;
 }

--- a/src/client/stylesheets/modules/home/home.module.scss
+++ b/src/client/stylesheets/modules/home/home.module.scss
@@ -1,28 +1,50 @@
-@import "../../utils/styles";
+@import '../../utils/styles';
 
 .mainContainer {
-  display:flex;
-  flex-direction:column;
+  display: flex;
+  flex-direction: column;
 }
 
 .leftContainer {
-  display:flex;
-  padding-left: 50px;
-  flex-direction:column;
+  display: flex;
+  flex-direction: column;
   align-items: center;
+
+  @media (min-width: 1160px) {
+    padding-left: 50px;
+  }
 }
 
-.rightContainer{
-  color:#757575;
-  padding-left:150px;
-  font-size:19px;
+.rightContainer {
+  color: #999999;
+  font-size: 19px;
+  margin: auto;
+  max-width: 25rem;
+
+  @media (min-width: 1160px) {
+    padding-left: 150px;
+  }
+}
+
+.noActivity {
+  border-bottom: 1px solid #757575;
+  margin: 2rem auto 1rem;
+  max-width: 320px;
+
+  @media (min-width: 1160px) {
+    margin: 0 0 100%;
+  }
 }
 
 .lowerContainer {
-  padding-top:30px;
+  padding-top: 30px;
   display: flex;
-  flex-direction: row;
   justify-content: center;
+  flex-direction: column;
+
+  @media (min-width: 1160px) {
+    flex-direction: row;
+  }
 }
 
 .header {
@@ -37,13 +59,15 @@
 }
 
 .hero {
-  height:300px;
+  margin: auto;
+  max-width: 90%;
+  width: 500px;
 }
 
-.welcomeMessage{
-  line-height:1.3;
+.welcomeMessage {
+  line-height: 1.3;
   color: #757575;
-  width:310px;
+  width: 310px;
   text-align: center;
   margin: 20px 0;
 }

--- a/src/client/stylesheets/modules/search/search.module.scss
+++ b/src/client/stylesheets/modules/search/search.module.scss
@@ -29,6 +29,7 @@
 }
 
 .search-wrapper {
+  position: relative;
   width: 310px;
 }
 
@@ -115,10 +116,15 @@ button.ais-SearchBox-submit {
 
 .hits-wrapper {
   height: 400px;
-  width: 300px;
-  padding-right: 60px;
+  width: 100%;
+  padding-right: 2rem;
   overflow: auto;
   margin-top: 16px;
+  
+  @media (min-width: 580px) {
+    padding-right: 60px;
+    max-width: 300px;
+  }
 }
 
 ul {
@@ -137,8 +143,6 @@ li {
   width: 1.2em;
   height: 1.2em;
   position: absolute;
-  top: 104px;
-  right: 365px;
   stroke: #888888;
   stroke-width: 0.5;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,7 @@
 
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1"> 
     <title>Webpack UI</title>
   </head>
 


### PR DESCRIPTION
Fixes #12.

Does away with all the absolute positioning I could find and replaces it with glorious flexbox.

Sets up breakpoints at *580px* and *1160px* based on the existing code.

Prefers a mobile-first approach with min-width media queries.

<table>
<thead>
<tr>
<th>Area</th>
<th>Mobile (Pixel 2)</th>
<th>Tablet (iPad Pro)</th>
<th>Full (1200px)</th>
</tr>
</thead>
<tbody>
<tr>
<th>Home</th>
<td><img alt="Home screenshot at mobile resolution" src="https://user-images.githubusercontent.com/3335181/110738379-2dcc3a00-81fd-11eb-9380-a198390569a7.png" /></td>
<td><img alt="Home screenshot at tablet resolution" src="https://user-images.githubusercontent.com/3335181/110738382-2efd6700-81fd-11eb-8027-1aeb7801aaba.png" /></td>
<td><img alt="Home screenshot at full resolution" src="https://user-images.githubusercontent.com/3335181/110738490-68ce6d80-81fd-11eb-948f-57b11b8253cf.png" /></td>
</tr>

<tr>
<th>Create Project</th>
<td><img alt="Create Project screenshot at mobile resolution" src="https://user-images.githubusercontent.com/3335181/110738750-da0e2080-81fd-11eb-9dec-348e05d54fe9.png" /></td>
<td><img alt="Create Project screenshot at tablet resolution" src="https://user-images.githubusercontent.com/3335181/110738747-d8dcf380-81fd-11eb-823e-c962366ebb63.png" /></td>
<td><img alt="Create Project screenshot at full resolution" src="https://user-images.githubusercontent.com/3335181/110738743-d7abc680-81fd-11eb-8539-d609fc8edab8.png" /></td>
</tr>

<tr>
<th>Starter Pack</th>
<td><img alt="Starter Pack screenshot at mobile resolution" src="https://user-images.githubusercontent.com/3335181/110738885-0f1a7300-81fe-11eb-882e-db38deb579a5.png" /></td>
<td><img alt="Starter Pack screenshot at tablet resolution" src="https://user-images.githubusercontent.com/3335181/110738889-104ba000-81fe-11eb-9804-f3111c94fb5c.png" /></td>
<td><img alt="Starter Pack screenshot at full resolution" src="https://user-images.githubusercontent.com/3335181/110738893-10e43680-81fe-11eb-8d7a-2ab56f702707.png" /></td>
</tr>

</tbody>
</table>

